### PR TITLE
Getting started

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  NewCops: enable
   Exclude: 
     - /**/bin/*
     - /**/gemfiles/**
@@ -9,7 +10,7 @@ Layout/ArgumentAlignment:
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
-  Metrics:
+Metrics:
   Exclude:
     - /**/spec/**/*
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,8 +18,5 @@ Metrics/BlockLength:
   Exclude:
     - /**/spec/**/*
 
-Style/Documentation:
-  Enabled: false
-
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,14 @@ Layout/ArgumentAlignment:
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
+  Metrics:
+  Exclude:
+    - /**/spec/**/*
+
+Metrics/BlockLength:
+  Exclude:
+    - /**/spec/**/*
+
 Style/Documentation:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "appraisal"
+gem "database_cleaner-active_record"
 gem "pg"
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,10 @@ GEM
       thor (>= 0.14.0)
     ast (2.4.0)
     concurrent-ruby (1.1.6)
+    database_cleaner (1.8.4)
+    database_cleaner-active_record (1.8.0)
+      activerecord
+      database_cleaner (~> 1.8.0)
     diff-lcs (1.3)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
@@ -71,6 +75,7 @@ PLATFORMS
 DEPENDENCIES
   appraisal
   cursor_pager!
+  database_cleaner-active_record
   pg
   rake (~> 12.0)
   rspec (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
-    rubocop (0.81.0)
+    rubocop (0.82.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)

--- a/gemfiles/activerecord_5.2.gemfile
+++ b/gemfiles/activerecord_5.2.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "appraisal"
+gem "database_cleaner-active_record"
 gem "pg"
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"

--- a/gemfiles/activerecord_5.2.gemfile.lock
+++ b/gemfiles/activerecord_5.2.gemfile.lock
@@ -25,6 +25,10 @@ GEM
     arel (9.0.0)
     ast (2.4.0)
     concurrent-ruby (1.1.6)
+    database_cleaner (1.8.4)
+    database_cleaner-active_record (1.8.0)
+      activerecord
+      database_cleaner (~> 1.8.0)
     diff-lcs (1.3)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
@@ -72,6 +76,7 @@ DEPENDENCIES
   activerecord (~> 5.2.0)
   appraisal
   cursor_pager!
+  database_cleaner-active_record
   pg
   rake (~> 12.0)
   rspec (~> 3.0)

--- a/gemfiles/activerecord_6.0.gemfile
+++ b/gemfiles/activerecord_6.0.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "appraisal"
+gem "database_cleaner-active_record"
 gem "pg"
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"

--- a/gemfiles/activerecord_6.0.gemfile.lock
+++ b/gemfiles/activerecord_6.0.gemfile.lock
@@ -24,6 +24,10 @@ GEM
       thor (>= 0.14.0)
     ast (2.4.0)
     concurrent-ruby (1.1.6)
+    database_cleaner (1.8.4)
+    database_cleaner-active_record (1.8.0)
+      activerecord
+      database_cleaner (~> 1.8.0)
     diff-lcs (1.3)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
@@ -72,6 +76,7 @@ DEPENDENCIES
   activerecord (~> 6.0.0)
   appraisal
   cursor_pager!
+  database_cleaner-active_record
   pg
   rake (~> 12.0)
   rspec (~> 3.0)

--- a/lib/cursor_pager.rb
+++ b/lib/cursor_pager.rb
@@ -12,4 +12,6 @@ require "cursor_pager/cursor_not_found_error"
 require "cursor_pager/order_value_error"
 
 require "cursor_pager/order_value"
+require "cursor_pager/limit_relation"
+require "cursor_pager/slice_relation"
 require "cursor_pager/page"

--- a/lib/cursor_pager.rb
+++ b/lib/cursor_pager.rb
@@ -2,6 +2,7 @@
 
 require "cursor_pager/version"
 require "cursor_pager/page"
+require "cursor_pager/order_value"
 
 module CursorPager
   class Error < StandardError; end

--- a/lib/cursor_pager.rb
+++ b/lib/cursor_pager.rb
@@ -12,6 +12,7 @@ require "cursor_pager/cursor_not_found_error"
 require "cursor_pager/order_value_error"
 
 require "cursor_pager/order_value"
+require "cursor_pager/order_values"
 require "cursor_pager/limit_relation"
 require "cursor_pager/slice_relation"
 require "cursor_pager/page"

--- a/lib/cursor_pager.rb
+++ b/lib/cursor_pager.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "cursor_pager/version"
+require "cursor_pager/page"
 
 module CursorPager
   class Error < StandardError; end

--- a/lib/cursor_pager.rb
+++ b/lib/cursor_pager.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
 require "cursor_pager/version"
-require "cursor_pager/page"
-require "cursor_pager/order_value"
 
 module CursorPager
-  class Error < StandardError; end
-  # Your code goes here...
+  class Error < StandardError
+  end
 end
+
+require "cursor_pager/conflicting_orders_error"
+require "cursor_pager/cursor_not_found_error"
+require "cursor_pager/order_value_error"
+
+require "cursor_pager/order_value"
+require "cursor_pager/page"

--- a/lib/cursor_pager/conflicting_orders_error.rb
+++ b/lib/cursor_pager/conflicting_orders_error.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module CursorPager
+  # Will be raised when the relation is ordered by multiple attributes but in
+  # different directions.
   class ConflictingOrdersError < Error
     MESSAGE = <<~MESSAGE
       Ordering by multiple attributes requires they are all ordered in the

--- a/lib/cursor_pager/conflicting_orders_error.rb
+++ b/lib/cursor_pager/conflicting_orders_error.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module CursorPager
+  class ConflictingOrdersError < Error
+    MESSAGE = <<~MESSAGE
+      Ordering by multiple attributes requires they are all ordered in the
+      same direction.
+    MESSAGE
+
+    def initialize
+      super(MESSAGE)
+    end
+  end
+end

--- a/lib/cursor_pager/cursor_not_found_error.rb
+++ b/lib/cursor_pager/cursor_not_found_error.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module CursorPager
+  class CursorNotFoundError < Error
+    def initialize(cursor)
+      message = "Couldn't find item for cursor #{cursor}."
+
+      super(message)
+    end
+  end
+end

--- a/lib/cursor_pager/cursor_not_found_error.rb
+++ b/lib/cursor_pager/cursor_not_found_error.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module CursorPager
+  # Will be raised when the cursor's record couldn't be found in the relation.
   class CursorNotFoundError < Error
     def initialize(cursor)
       message = "Couldn't find item for cursor #{cursor}."

--- a/lib/cursor_pager/limit_relation.rb
+++ b/lib/cursor_pager/limit_relation.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module CursorPager
+  # Applies first and last limits to a relation.
   class LimitRelation
     attr_reader :base_relation, :first, :last
 

--- a/lib/cursor_pager/limit_relation.rb
+++ b/lib/cursor_pager/limit_relation.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module CursorPager
+  class LimitRelation
+    attr_reader :base_relation, :first, :last
+
+    def initialize(base_relation, first, last)
+      @base_relation = base_relation
+      @first = first
+      @last = last
+    end
+
+    def call
+      relation = base_relation
+
+      relation = apply_first(relation) if first.present?
+      relation = apply_last(relation) if last.present?
+
+      relation
+    end
+
+    private
+
+    # Apply first if it sets a stricter limit than the one already applied
+    def apply_first(relation)
+      previous_limit = relation.limit_value
+
+      if previous_limit.nil? || previous_limit > first
+        relation.limit(first)
+      else
+        relation
+      end
+    end
+
+    # Apply last if it's a smaller slice than the previous limit
+    def apply_last(relation)
+      previous_limit = relation.limit_value
+
+      if previous_limit.present?
+        if last <= previous_limit
+          relation = apply_stricter_last(relation, previous_limit)
+        end
+      else
+        relation = apply_last_withouth_previous_limit(relation)
+      end
+
+      relation
+    end
+
+    def apply_stricter_last(relation, previous_limit)
+      offset = (relation.offset_value || 0) + (previous_limit - last)
+
+      relation.offset(offset).limit(last)
+    end
+
+    def apply_last_withouth_previous_limit(relation)
+      count = base_relation.count
+      previous_offset = relation.offset_value || 0
+      offset = previous_offset + count - [last, count].min
+
+      relation.offset(offset).limit(last)
+    end
+  end
+end

--- a/lib/cursor_pager/limit_relation.rb
+++ b/lib/cursor_pager/limit_relation.rb
@@ -55,7 +55,7 @@ module CursorPager
     end
 
     def apply_last_withouth_previous_limit(relation)
-      count = base_relation.count
+      count = base_relation.size
       previous_offset = relation.offset_value || 0
       offset = previous_offset + count - [last, count].min
 

--- a/lib/cursor_pager/order_value.rb
+++ b/lib/cursor_pager/order_value.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module CursorPager
+  class OrderValueError < StandardError
+  end
+
+  class OrderValue
+    PARENTHESIS_REGEX = /[\(\)]/.freeze
+
+    attr_reader :attribute, :direction
+
+    class << self
+      # A relation's order_values can either be an empty array, an array
+      # including just one string, or an array of arel ordering nodes.
+      def from_relation(relation)
+        relation.order_values.uniq.reject(&:blank?).flat_map do |value|
+          case value
+          when Arel::Nodes::Ordering
+            new(relation, value.value.name, value.direction)
+          when String
+            from_order_string(relation, value)
+          end
+        end
+      end
+
+      def default_for(relation, order_direction)
+        new(relation, relation.primary_key, order_direction || :asc)
+      end
+
+      private
+
+      def from_order_string(relation, value)
+        if value.match?(PARENTHESIS_REGEX)
+          raise OrderValueError, "Order values can't include functions."
+        end
+
+        value.split(",").map do |split_value|
+          new(relation, *split_value.squish.split)
+        end
+      end
+    end
+
+    def initialize(relation, attribute, direction = :asc)
+      @relation = relation
+      @attribute = attribute
+      @direction = direction.downcase.to_sym
+    end
+
+    def primary_key?
+      relation.primary_key == attribute
+    end
+
+    def type
+      relation.type_for_attribute(attribute).type
+    end
+
+    def prefixed_attribute
+      return attribute if attribute.include?(".")
+
+      "#{relation.table_name}.#{attribute}"
+    end
+
+    def select_alias
+      prefixed_attribute.tr(".", "_")
+    end
+
+    def select_string
+      "#{prefixed_attribute} AS #{select_alias}"
+    end
+
+    def order_string
+      "#{prefixed_attribute} #{direction}"
+    end
+
+    private
+
+    attr_reader :relation
+  end
+end

--- a/lib/cursor_pager/order_value.rb
+++ b/lib/cursor_pager/order_value.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 module CursorPager
-  class OrderValueError < StandardError
-  end
-
   class OrderValue
     PARENTHESIS_REGEX = /[\(\)]/.freeze
 

--- a/lib/cursor_pager/order_value.rb
+++ b/lib/cursor_pager/order_value.rb
@@ -20,10 +20,6 @@ module CursorPager
         end
       end
 
-      def default_for(relation, order_direction)
-        new(relation, relation.primary_key, order_direction || :asc)
-      end
-
       private
 
       def from_order_string(relation, value)

--- a/lib/cursor_pager/order_value.rb
+++ b/lib/cursor_pager/order_value.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module CursorPager
+  # Wraps ActiveRecord's order values.
+  # Depending on how the order of the relation is defined, ActiveRecord will
+  # give you multiple arel nodes or just one string. This deals with the
+  # differences so we don't have to do it anywhere else.
   class OrderValue
     PARENTHESIS_REGEX = /[\(\)]/.freeze
 

--- a/lib/cursor_pager/order_value_error.rb
+++ b/lib/cursor_pager/order_value_error.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module CursorPager
+  class OrderValueError < Error
+  end
+end

--- a/lib/cursor_pager/order_values.rb
+++ b/lib/cursor_pager/order_values.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "forwardable"
+
+module CursorPager
+  class OrderValues
+    extend Forwardable
+    include Enumerable
+
+    def_delegators :@collection, :each, :<<, :size, :present?
+
+    # A relation's order_values can either be an empty array, an array including
+    # just one string, or an array of arel ordering nodes.
+    def self.from_relation(relation)
+      arel_order_values = relation.order_values.uniq.reject(&:blank?)
+      collection = arel_order_values.flat_map do |value|
+        case value
+        when Arel::Nodes::Ordering
+          OrderValue.from_arel_node(relation, value)
+        when String
+          OrderValue.from_order_string(relation, value)
+        end
+      end
+
+      new(collection)
+    end
+
+    def initialize(collection = [])
+      @collection = collection
+    end
+
+    def direction
+      @collection.first&.direction
+    end
+
+    def order_string
+      @collection.map(&:order_string).join(", ")
+    end
+  end
+end

--- a/lib/cursor_pager/order_values.rb
+++ b/lib/cursor_pager/order_values.rb
@@ -3,6 +3,7 @@
 require "forwardable"
 
 module CursorPager
+  # OrderValue collection wrapper.
   class OrderValues
     extend Forwardable
     include Enumerable

--- a/lib/cursor_pager/page.rb
+++ b/lib/cursor_pager/page.rb
@@ -1,25 +1,6 @@
 # frozen_string_literal: true
 
 module CursorPager
-  class CursorNotFoundError < StandardError
-    def initialize(cursor)
-      message = "Couldn't find item for cursor #{cursor}."
-
-      super(message)
-    end
-  end
-
-  class ConflictingOrdersError < StandardError
-    MESSAGE = <<~MESSAGE
-      Ordering by multiple attributes requires they are all ordered in the
-      same direction.
-    MESSAGE
-
-    def initialize
-      super(MESSAGE)
-    end
-  end
-
   class Page
     attr_reader :relation, :first, :last, :after, :before, :order_values
 

--- a/lib/cursor_pager/page.rb
+++ b/lib/cursor_pager/page.rb
@@ -10,7 +10,7 @@ module CursorPager
       @last = last
       @after = after
       @before = before
-      @order_values = OrderValue.from_relation(relation)
+      @order_values = OrderValues.from_relation(relation)
 
       add_default_order
       verify_order_directions!
@@ -49,7 +49,7 @@ module CursorPager
     def add_default_order
       return if sufficiently_ordered?
 
-      direction = order_direction || :asc
+      direction = order_values.direction || :asc
 
       @order_values << OrderValue.new(relation, relation.primary_key, direction)
     end
@@ -80,11 +80,7 @@ module CursorPager
     end
 
     def ordered_relation
-      @ordered_relation ||= relation.reorder(order_string)
-    end
-
-    def order_string
-      order_values.map(&:order_string).join(", ")
+      @ordered_relation ||= relation.reorder(order_values.order_string)
     end
 
     def before_limit_value
@@ -106,10 +102,6 @@ module CursorPager
       raise CursorNotFoundError, cursor if item.blank?
 
       order_values.map { |value| item[value.select_alias] }
-    end
-
-    def order_direction
-      order_values.first&.direction
     end
   end
 end

--- a/lib/cursor_pager/page.rb
+++ b/lib/cursor_pager/page.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module CursorPager
+  # The main class that coordinates the whole pagination.
   class Page
     attr_reader :relation, :first, :last, :after, :before, :order_values
 

--- a/lib/cursor_pager/page.rb
+++ b/lib/cursor_pager/page.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module CursorPager
+  class Page
+    attr_reader :relation, :first, :last, :after, :before
+
+    def initialize(relation, first: nil, last: nil, after: nil, before: nil)
+      @relation = relation
+      @first = first
+      @last = last
+      @after = after
+      @before = before
+    end
+
+    def previous_page?
+      false
+    end
+
+    def next_page?
+      false
+    end
+
+    def cursor_for(item)
+      Base64.strict_encode64(item.id.to_s)
+    end
+
+    def records
+      relation.to_a
+    end
+  end
+end

--- a/lib/cursor_pager/page.rb
+++ b/lib/cursor_pager/page.rb
@@ -50,7 +50,9 @@ module CursorPager
     def add_default_order
       return if sufficiently_ordered?
 
-      @order_values << OrderValue.default_for(relation, order_direction)
+      direction = order_direction || :asc
+
+      @order_values << OrderValue.new(relation, relation.primary_key, direction)
     end
 
     def sufficiently_ordered?

--- a/lib/cursor_pager/page.rb
+++ b/lib/cursor_pager/page.rb
@@ -1,8 +1,27 @@
 # frozen_string_literal: true
 
 module CursorPager
+  class CursorNotFoundError < StandardError
+    def initialize(cursor)
+      message = "Couldn't find item for cursor #{cursor}."
+
+      super(message)
+    end
+  end
+
+  class ConflictingOrdersError < StandardError
+    MESSAGE = <<~MESSAGE
+      Ordering by multiple attributes requires they are all ordered in the
+      same direction.
+    MESSAGE
+
+    def initialize
+      super(MESSAGE)
+    end
+  end
+
   class Page
-    attr_reader :relation, :first, :last, :after, :before
+    attr_reader :relation, :first, :last, :after, :before, :order_values
 
     def initialize(relation, first: nil, last: nil, after: nil, before: nil)
       @relation = relation
@@ -10,6 +29,10 @@ module CursorPager
       @last = last
       @after = after
       @before = before
+      @order_values = OrderValue.from_relation(relation)
+
+      add_default_order
+      verify_order_directions!
     end
 
     def previous_page?
@@ -25,7 +48,128 @@ module CursorPager
     end
 
     def records
-      relation.to_a
+      @records ||= limited_relation.to_a
+    end
+
+    private
+
+    def add_default_order
+      return if sufficiently_ordered?
+
+      @order_values << OrderValue.default_for(relation, order_direction)
+    end
+
+    def sufficiently_ordered?
+      order_values.present? && order_values.all? do |value|
+        value.primary_key? || value.type == :datetime
+      end
+    end
+
+    def verify_order_directions!
+      return if order_values.map(&:direction).uniq.size == 1
+
+      raise ConflictingOrdersError
+    end
+
+    def limited_relation
+      return @limited_relation if defined? @limited_relation
+
+      paginated_relation = sliced_relation
+      previous_limit = paginated_relation.limit_value
+
+      if first && (previous_limit.nil? || previous_limit > first)
+        # `first` would create a stricter limit that the one already applied, so add it
+        paginated_relation = paginated_relation.limit(first)
+      end
+
+      if last
+        if (lv = paginated_relation.limit_value)
+          if last <= lv
+            # `last` is a smaller slice than the current limit, so apply it
+            offset = (paginated_relation.offset_value || 0) + (lv - last)
+            paginated_relation = paginated_relation.offset(offset)
+            paginated_relation = paginated_relation.limit(last)
+          end
+        else
+          # No limit, so get the last items
+          sliced_relation_count = @sliced_relation.count
+          offset = (paginated_relation.offset_value || 0) + sliced_relation_count - [last, sliced_relation_count].min
+          paginated_relation = paginated_relation.offset(offset)
+          paginated_relation = paginated_relation.limit(last)
+        end
+      end
+
+      @paged_nodes_offset = paginated_relation.offset_value
+      @limited_relation = paginated_relation
+    end
+
+    def sliced_relation
+      return @sliced_relation if defined? @sliced_relation
+
+      paginated_relation = relation
+
+      paginated_relation = apply_order_values(paginated_relation)
+      paginated_relation = apply_after(paginated_relation)
+      paginated_relation = apply_before(paginated_relation)
+
+      @sliced_relation = paginated_relation
+    end
+
+    def apply_order_values(paginated_relation)
+      order = order_values.map(&:order_string).join(", ")
+
+      paginated_relation.reorder(order)
+    end
+
+    def apply_after(paginated_relation)
+      after_limit_value = after && limit_value_for(after)
+
+      return paginated_relation if after_limit_value.blank?
+
+      if order_direction == :asc
+        slice_relation(paginated_relation, ">", after_limit_value)
+      else
+        slice_relation(paginated_relation, "<", after_limit_value)
+      end
+    end
+
+    def apply_before(paginated_relation)
+      before_limit_value = before && limit_value_for(before)
+
+      return paginated_relation if before_limit_value.blank?
+
+      if order_direction == :asc
+        slice_relation(paginated_relation, "<", before_limit_value)
+      else
+        slice_relation(paginated_relation, ">", before_limit_value)
+      end
+    end
+
+    def limit_value_for(cursor)
+      id = decode(cursor)
+
+      return if id.blank?
+
+      selects = order_values.map(&:select_string)
+      item = relation.where(id: id).select(selects).first
+
+      raise CursorNotFoundError, cursor if item.blank?
+
+      order_values.map { |value| item[value.select_alias] }
+    end
+
+    def decode(str)
+      Base64.strict_decode64(str)
+    end
+
+    def order_direction
+      order_values.first&.direction
+    end
+
+    def slice_relation(paginated_relation, operator, value)
+      slice_attribute = order_values.map(&:prefixed_attribute).join(", ")
+
+      paginated_relation.where("(#{slice_attribute}) #{operator} (?)", value)
     end
   end
 end

--- a/lib/cursor_pager/page.rb
+++ b/lib/cursor_pager/page.rb
@@ -38,7 +38,7 @@ module CursorPager
     end
 
     def cursor_for(item)
-      Base64.strict_encode64(item.id.to_s)
+      Base64.urlsafe_encode64(item.id.to_s)
     end
 
     def records
@@ -144,7 +144,7 @@ module CursorPager
     end
 
     def limit_value_for(cursor)
-      id = decode(cursor)
+      id = Base64.urlsafe_decode64(cursor)
 
       return if id.blank?
 
@@ -154,10 +154,6 @@ module CursorPager
       raise CursorNotFoundError, cursor if item.blank?
 
       order_values.map { |value| item[value.select_alias] }
-    end
-
-    def decode(str)
-      Base64.strict_decode64(str)
     end
 
     def order_direction

--- a/lib/cursor_pager/slice_relation.rb
+++ b/lib/cursor_pager/slice_relation.rb
@@ -3,13 +3,13 @@
 module CursorPager
   # Applies after and before cursors to a relation.
   class SliceRelation
-    attr_reader :base_relation, :order_values, :after, :before
+    attr_reader :base_relation, :order_values, :after_values, :before_values
 
-    def initialize(base_relation, order_values, after, before)
+    def initialize(base_relation, order_values, after_values, before_values)
       @base_relation = base_relation
       @order_values = order_values
-      @after = after
-      @before = before
+      @after_values = after_values
+      @before_values = before_values
     end
 
     def call
@@ -24,22 +24,22 @@ module CursorPager
     private
 
     def apply_after(relation)
-      return relation if after.blank?
+      return relation if after_values.blank?
 
       if order_values.direction == :asc
-        slice_relation(relation, ">", after)
+        slice_relation(relation, ">", after_values)
       else
-        slice_relation(relation, "<", after)
+        slice_relation(relation, "<", after_values)
       end
     end
 
     def apply_before(relation)
-      return relation if before.blank?
+      return relation if before_values.blank?
 
       if order_values.direction == :asc
-        slice_relation(relation, "<", before)
+        slice_relation(relation, "<", before_values)
       else
-        slice_relation(relation, ">", before)
+        slice_relation(relation, ">", before_values)
       end
     end
 

--- a/lib/cursor_pager/slice_relation.rb
+++ b/lib/cursor_pager/slice_relation.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module CursorPager
+  class SliceRelation
+    attr_reader :base_relation, :order_values, :after, :before
+
+    def initialize(base_relation, order_values, after, before)
+      @base_relation = base_relation
+      @order_values = order_values
+      @after = after
+      @before = before
+    end
+
+    def call
+      relation = base_relation
+
+      relation = apply_after(relation)
+      relation = apply_before(relation)
+
+      relation
+    end
+
+    private
+
+    def apply_after(relation)
+      return relation if after.blank?
+
+      if order_direction == :asc
+        slice_relation(relation, ">", after)
+      else
+        slice_relation(relation, "<", after)
+      end
+    end
+
+    def apply_before(relation)
+      return relation if before.blank?
+
+      if order_direction == :asc
+        slice_relation(relation, "<", before)
+      else
+        slice_relation(relation, ">", before)
+      end
+    end
+
+    def slice_relation(relation, operator, value)
+      slice_attribute = order_values.map(&:prefixed_attribute).join(", ")
+
+      relation.where("(#{slice_attribute}) #{operator} (?)", value)
+    end
+
+    def order_direction
+      order_values.first&.direction
+    end
+  end
+end

--- a/lib/cursor_pager/slice_relation.rb
+++ b/lib/cursor_pager/slice_relation.rb
@@ -25,7 +25,7 @@ module CursorPager
     def apply_after(relation)
       return relation if after.blank?
 
-      if order_direction == :asc
+      if order_values.direction == :asc
         slice_relation(relation, ">", after)
       else
         slice_relation(relation, "<", after)
@@ -35,7 +35,7 @@ module CursorPager
     def apply_before(relation)
       return relation if before.blank?
 
-      if order_direction == :asc
+      if order_values.direction == :asc
         slice_relation(relation, "<", before)
       else
         slice_relation(relation, ">", before)
@@ -46,10 +46,6 @@ module CursorPager
       slice_attribute = order_values.map(&:prefixed_attribute).join(", ")
 
       relation.where("(#{slice_attribute}) #{operator} (?)", value)
-    end
-
-    def order_direction
-      order_values.first&.direction
     end
   end
 end

--- a/lib/cursor_pager/slice_relation.rb
+++ b/lib/cursor_pager/slice_relation.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module CursorPager
+  # Applies after and before cursors to a relation.
   class SliceRelation
     attr_reader :base_relation, :order_values, :after, :before
 

--- a/spec/cursor_pager/limit_relation_spec.rb
+++ b/spec/cursor_pager/limit_relation_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+RSpec.describe CursorPager::LimitRelation do
+  describe "#call" do
+    it "doesn't change the relation if first & last are nil" do
+      2.times { User.create }
+      relation = User.order(:id)
+
+      limited_relation = described_class.new(relation, nil, nil).call
+
+      expect(limited_relation).to eq(relation)
+    end
+
+    context "when first is not null" do
+      it "is applied when there was no previous limit on the relation" do
+        users = 5.times.map { User.create }
+        relation = User.order(:id)
+
+        limited_relation = described_class.new(relation, 2, nil).call
+
+        expect(limited_relation).to eq(users.first(2))
+      end
+
+      it "is applied when it's stricter than the previous limit" do
+        users = 5.times.map { User.create }
+        relation = User.order(:id).limit(2)
+
+        limited_relation = described_class.new(relation, 1, nil).call
+
+        expect(limited_relation).to eq(users.first(1))
+      end
+
+      it "is not applied when the previous limit is stricter" do
+        5.times { User.create }
+        relation = User.order(:id).limit(1)
+
+        limited_relation = described_class.new(relation, 2, nil).call
+
+        expect(limited_relation).to eq(relation)
+      end
+    end
+
+    context "when last is not null" do
+      it "is applied when there was no previous limit on the relation" do
+        users = 5.times.map { User.create }
+        relation = User.order(:id)
+
+        limited_relation = described_class.new(relation, nil, 2).call
+
+        expect(limited_relation).to eq(users.last(2))
+      end
+
+      it "is applied when it's stricter than the previous limit" do
+        users = 5.times.map { User.create }
+        relation = User.order(:id).limit(2)
+
+        limited_relation = described_class.new(relation, nil, 1).call
+
+        expect(limited_relation).to eq(users.first(2).last(1))
+      end
+
+      it "is not applied when the previous limit is stricter" do
+        5.times { User.create }
+        relation = User.order(:id).limit(2)
+
+        limited_relation = described_class.new(relation, nil, 3).call
+
+        expect(limited_relation).to eq(relation)
+      end
+    end
+
+    context "when first and last are not null" do
+      it "does not apply last when first is stricter" do
+        5.times { User.create }
+        relation = User.order(:id)
+
+        limited_relation = described_class.new(relation, 2, 3).call
+
+        expect(limited_relation).to eq(relation.first(2))
+      end
+
+      it "applies last when it's stricter than first" do
+        5.times { User.create }
+        relation = User.order(:id)
+
+        limited_relation = described_class.new(relation, 4, 3).call
+
+        expect(limited_relation).to eq(relation.first(4).last(3))
+      end
+    end
+  end
+end

--- a/spec/cursor_pager/order_value_spec.rb
+++ b/spec/cursor_pager/order_value_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+RSpec.describe CursorPager::OrderValue do
+  describe ".from_relation" do
+    it "returns an empty collection when the order wasn't specified" do
+      relation = User.all
+      result = described_class.from_relation(relation)
+
+      expect(result.size).to eq(0)
+    end
+
+    context "when relation ordering specified as string" do
+      it "returns a collection of order values" do
+        relation = User.order("id ASC")
+        result = described_class.from_relation(relation)
+
+        expect(result).to all(be_a(described_class))
+        expect(result.size).to eq(1)
+      end
+
+      it "splits the ordering string" do
+        relation = User.order("id ASC, created_at")
+        result = described_class.from_relation(relation)
+
+        expect(result).to all(be_a(described_class))
+        expect(result.size).to eq(2)
+      end
+
+      it "defaults the direction to asc when it's not specified" do
+        relation = User.order("id")
+        result = described_class.from_relation(relation)
+
+        expect(result.first.direction).to eq(:asc)
+      end
+
+      it "it raises an exception when it includes a function" do
+        order = Arel.sql("COALESCE(published_at, created_at) ASC")
+        relation = User.order(order)
+
+        expect { described_class.from_relation(relation) }
+          .to raise_error(CursorPager::OrderValueError)
+      end
+    end
+
+    context "when relation ordering specified as hash" do
+      it "returns a collection of order values" do
+        relation = User.order(id: :asc)
+        result = described_class.from_relation(relation)
+
+        expect(result).to all(be_a(described_class))
+        expect(result.size).to eq(1)
+      end
+
+      it "parses the multiple order values" do
+        relation = User.order(id: :asc, created_at: :asc)
+        result = described_class.from_relation(relation)
+
+        expect(result).to all(be_a(described_class))
+        expect(result.size).to eq(2)
+      end
+
+      it "defaults the direction to asc when it's not specified" do
+        relation = User.order(:id)
+        result = described_class.from_relation(relation)
+
+        expect(result.first.direction).to eq(:asc)
+      end
+    end
+  end
+
+  describe "#primary_key?" do
+    it "returns true when the attribute is the relation's primary key" do
+      order_value = described_class.new(User.none, "id")
+
+      expect(order_value.primary_key?).to be(true)
+    end
+
+    it "returns false when the attribute isn't the relation's primary key" do
+      order_value = described_class.new(User.none, "created_at")
+
+      expect(order_value.primary_key?).to be(false)
+    end
+  end
+
+  describe "#type" do
+    it "returns the type of the attribute" do
+      relation = User.none
+      integer_order_value = described_class.new(relation, "id")
+      datetime_order_value = described_class.new(relation, "created_at")
+
+      expect(integer_order_value.type).to eq(:integer)
+      expect(datetime_order_value.type).to eq(:datetime)
+    end
+  end
+
+  describe "#prefixed_attribute" do
+    it "prefixes the attribute with the table name" do
+      order_value = described_class.new(User.none, "created_at")
+
+      expect(order_value.prefixed_attribute).to eq("users.created_at")
+    end
+
+    it "does not prefix already prefixed attributes" do
+      order_value = described_class.new(User.none, "users.created_at")
+
+      expect(order_value.prefixed_attribute).to eq("users.created_at")
+    end
+  end
+
+  describe "#select_alias" do
+    it "returns a select alias for the prefixed attribute" do
+      order_value = described_class.new(User.none, "created_at")
+
+      expect(order_value.select_alias).to eq("users_created_at")
+    end
+  end
+
+  describe "#select_string" do
+    it "builds a select string for the attribute with an alias" do
+      order_value = described_class.new(User.none, "created_at")
+
+      result = order_value.select_string
+
+      expect(result).to eq("users.created_at AS users_created_at")
+    end
+  end
+
+  describe "#order_string" do
+    it "builts an order string" do
+      order_value = described_class.new(User.none, "created_at")
+
+      expect(order_value.order_string).to eq("users.created_at asc")
+    end
+  end
+end

--- a/spec/cursor_pager/order_values_spec.rb
+++ b/spec/cursor_pager/order_values_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+RSpec.describe CursorPager::OrderValues do
+  describe ".from_relation" do
+    it "returns an empty collection when the order wasn't specified" do
+      relation = User.all
+      result = described_class.from_relation(relation)
+
+      expect(result.size).to eq(0)
+    end
+
+    context "when relation ordering specified as string" do
+      it "initializes the order values with that string" do
+        relation = User.order("id ASC, created_at ASC")
+
+        expect(CursorPager::OrderValue)
+          .to receive(:from_order_string)
+          .with(relation, "id ASC, created_at ASC")
+          .and_call_original
+
+        result = described_class.from_relation(relation)
+
+        expect(result.size).to eq(2)
+      end
+    end
+
+    context "when relation ordering specified as hash" do
+      it "initializes the order values with the corresponding arel nodes" do
+        relation = User.order(id: :asc)
+
+        expect(CursorPager::OrderValue)
+          .to receive(:from_arel_node)
+          .with(relation, kind_of(Arel::Nodes::Ascending))
+          .and_call_original
+
+        result = described_class.from_relation(relation)
+
+        expect(result.size).to eq(1)
+      end
+    end
+
+    describe "#direction" do
+      it "returns the direction of it's first item" do
+        relation = User.order(id: :desc)
+        order_values = described_class.from_relation(relation)
+
+        expect(order_values.direction).to eq(:desc)
+      end
+    end
+
+    describe "#order_string" do
+      it "joins the order strings of the whole collection" do
+        relation = User.order(created_at: :desc, id: :desc)
+        order_values = described_class.from_relation(relation)
+
+        expect(order_values.order_string)
+          .to eq("users.created_at desc, users.id desc")
+      end
+    end
+  end
+end

--- a/spec/cursor_pager/page_records_spec.rb
+++ b/spec/cursor_pager/page_records_spec.rb
@@ -1,0 +1,311 @@
+# frozen_string_literal: true
+
+RSpec.describe CursorPager::Page do
+  describe "#records" do
+    RSpec.shared_examples "works with first/last/before/after arguments" do
+      it "returns the whole collection without any arguments" do
+        expect(subject.records).to eq(ordered_collection)
+      end
+
+      context "when only given `first`" do
+        let(:first) { 2 }
+
+        it "limits the collection by that number" do
+          expect(subject.records).to eq(ordered_collection.first(2))
+        end
+      end
+
+      context "when only given `after`" do
+        let(:offset) { 1 }
+        let(:after_cursor) { encode_cursor(ordered_collection[offset]) }
+
+        it "returns the whole collection after the cursor" do
+          expected = ordered_collection[offset + 1..-1]
+
+          expect(subject.records.pluck(:id)).to eq(expected.map(&:id))
+        end
+      end
+
+      context "when given `first` and `after`" do
+        let(:offset) { 1 }
+        let(:first) { 2 }
+        let(:after_cursor) { encode_cursor(ordered_collection[offset]) }
+
+        it "returns the limited collection after the cursor" do
+          expected = ordered_collection[offset + 1..offset + first]
+
+          expect(subject.records).to eq(expected)
+        end
+      end
+
+      context "when only given `last`" do
+        let(:last) { 2 }
+
+        it "limits the collection by that number from the end" do
+          expected = ordered_collection.last(2)
+
+          expect(subject.records).to eq(expected)
+        end
+      end
+
+      context "when only given `before`" do
+        let(:offset) { 3 }
+        let(:before_cursor) { encode_cursor(ordered_collection[offset]) }
+
+        it "returns the whole collection before the cursor" do
+          expected = ordered_collection.first(offset)
+
+          expect(subject.records).to eq(expected)
+        end
+      end
+
+      context "when given `last` and `before`" do
+        let(:offset) { 3 }
+        let(:last) { 2 }
+        let(:before_cursor) { encode_cursor(ordered_collection[offset]) }
+
+        it "returns the limited collection before the cursor" do
+          expected = ordered_collection.first(offset).last(2)
+
+          expect(subject.records).to eq(expected)
+        end
+      end
+
+      context "when no item could be found for the given `after`" do
+        let(:after_cursor) { encode_cursor(double(id: relation.maximum(:id) + 1)) }
+
+        it "returns the whole collection after the cursor" do
+          expect { subject.records }.to raise_error(CursorPager::CursorNotFoundError)
+        end
+      end
+
+      context "when no item could be found for the given `before`" do
+        let(:before_cursor) { encode_cursor(double(id: relation.maximum(:id) + 1)) }
+
+        it "returns the whole collection after the cursor" do
+          expect { subject.records }.to raise_error(CursorPager::CursorNotFoundError)
+        end
+      end
+    end
+
+    def encode_cursor(item)
+      described_class.new(User.all).cursor_for(item)
+    end
+
+    let(:first) { nil }
+    let(:last) { nil }
+    let(:after_cursor) { nil }
+    let(:before_cursor) { nil }
+
+    subject do
+      described_class.new(
+        relation,
+        first: first,
+        last: last,
+        after: after_cursor,
+        before: before_cursor
+      )
+    end
+
+    context "it orders by primary key when no was predefined" do
+      let!(:user2) { User.create(id: 2) }
+      let!(:user3) { User.create(id: 3) }
+      let!(:user5) { User.create(id: 5) }
+      let!(:user1) { User.create(id: 1) }
+      let!(:user4) { User.create(id: 4) }
+
+      let(:relation) { User.all }
+      let(:ordered_collection) do
+        [user1, user2, user3,
+         user4, user5]
+      end
+
+      include_examples "works with first/last/before/after arguments"
+    end
+
+    context "when ordering by primary key" do
+      let!(:user2) { User.create(id: 2) }
+      let!(:user3) { User.create(id: 3) }
+      let!(:user5) { User.create(id: 5) }
+      let!(:user1) { User.create(id: 1) }
+      let!(:user4) { User.create(id: 4) }
+
+      context "without explicitly specifying the order" do
+        let(:relation) { User.order(:id) }
+        let(:ordered_collection) { [user1, user2, user3, user4, user5] }
+
+        include_examples "works with first/last/before/after arguments"
+      end
+
+      context "in ascending order" do
+        let(:relation) { User.order(id: :asc) }
+        let(:ordered_collection) { [user1, user2, user3, user4, user5] }
+
+        include_examples "works with first/last/before/after arguments"
+      end
+
+      context "in descending order" do
+        let(:relation) { User.order(id: :desc) }
+        let(:ordered_collection) { [user5, user4, user3, user2, user1] }
+
+        include_examples "works with first/last/before/after arguments"
+      end
+    end
+
+    context "when ordering by timestamp" do
+      let!(:user1) { User.create(created_at: 5.hours.ago) }
+      let!(:user2) { User.create(created_at: 4.hours.ago) }
+      let!(:user3) { User.create(created_at: 3.hours.ago) }
+      let!(:user4) { User.create(created_at: 2.hours.ago) }
+      let!(:user5) { User.create(created_at: 1.hour.ago) }
+
+      context "in ascending order" do
+        let(:relation) { User.order(created_at: :asc) }
+        let(:ordered_collection) { [user1, user2, user3, user4, user5] }
+
+        include_examples "works with first/last/before/after arguments"
+      end
+
+      context "in descending order" do
+        let(:relation) { User.order(created_at: :desc) }
+        let(:ordered_collection) { [user5, user4, user3, user2, user1] }
+
+        include_examples "works with first/last/before/after arguments"
+      end
+    end
+
+    context "when ordering by timestamp and additionally by primary key" do
+      let(:time1) { 2.hours.ago }
+      let(:time2) { 1.hour.ago }
+      let!(:user1) { User.create(id: 1, created_at: time1) }
+      let!(:user2) { User.create(id: 2, created_at: time2) }
+      let!(:user3) { User.create(id: 3, created_at: time1) }
+      let!(:user4) { User.create(id: 4, created_at: time2) }
+      let!(:user5) { User.create(id: 5, created_at: Time.current) }
+
+      context "in ascending order" do
+        let(:relation) { User.order(created_at: :asc, id: :asc) }
+        let(:ordered_collection) { [user1, user3, user2, user4, user5] }
+
+        include_examples "works with first/last/before/after arguments"
+      end
+
+      context "in descending order" do
+        let(:relation) { User.order(created_at: :desc, id: :desc) }
+        let(:ordered_collection) { [user5, user4, user2, user3, user1] }
+
+        include_examples "works with first/last/before/after arguments"
+      end
+    end
+
+    context "when ordered by two attributes in different directions" do
+      let(:relation) { User.order(created_at: :asc, id: :desc) }
+
+      it "raises an exception" do
+        expect { subject }.to raise_error(CursorPager::ConflictingOrdersError)
+      end
+    end
+
+    context "it orders by ID secondarily when ordering by a non-datetime or primary key value" do
+      let!(:user1) { User.create(id: 1, name: "Bob") }
+      let!(:user2) { User.create(id: 2, name: "Bob") }
+      let!(:user3) { User.create(id: 3, name: "Alice") }
+      let!(:user4) { User.create(id: 4, name: "Alice") }
+      let!(:user5) { User.create(id: 5, name: "Bob") }
+
+      context "in ascending order" do
+        let(:relation) { User.order(name: :asc) }
+        let(:ordered_collection) { [user3, user4, user1, user2, user5] }
+
+        include_examples "works with first/last/before/after arguments"
+      end
+
+      context "in descending order" do
+        let(:relation) { User.order(name: :desc) }
+        let(:ordered_collection) { [user5, user2, user1, user4, user3] }
+
+        include_examples "works with first/last/before/after arguments"
+      end
+    end
+
+    context "when order values are strings" do
+      let(:time1) { 2.hours.ago }
+      let(:time2) { 1.hour.ago }
+      let!(:user1) { User.create(id: 1, created_at: time1) }
+      let!(:user2) { User.create(id: 2, created_at: time2) }
+      let!(:user3) { User.create(id: 3, created_at: time1) }
+      let!(:user4) { User.create(id: 4, created_at: time2) }
+      let!(:user5) { User.create(id: 5, created_at: Time.current) }
+
+      context "without explicitly specifying the order" do
+        let(:relation) { User.order("id") }
+        let(:ordered_collection) { [user1, user2, user3, user4, user5] }
+
+        include_examples "works with first/last/before/after arguments"
+      end
+
+      context "in ascending order" do
+        let(:relation) { User.order("id ASC") }
+        let(:ordered_collection) { [user1, user2, user3, user4, user5] }
+
+        include_examples "works with first/last/before/after arguments"
+      end
+
+      context "in descending order" do
+        let(:relation) { User.order("id desc") }
+        let(:ordered_collection) { [user5, user4, user3, user2, user1] }
+
+        include_examples "works with first/last/before/after arguments"
+      end
+
+      context "with multiple values" do
+        let(:relation) { User.order("created_at ASC, id ASC") }
+        let(:ordered_collection) { [user1, user3, user2, user4, user5] }
+
+        include_examples "works with first/last/before/after arguments"
+      end
+    end
+
+    context "when ordering a relation including joins" do
+      let!(:user1) { User.create(id: 1) }
+      let!(:user2) { User.create(id: 2) }
+      let!(:user3) { User.create(id: 3) }
+      let!(:user4) { User.create(id: 4) }
+      let!(:user5) { User.create(id: 5) }
+      let(:relation) { User.left_outer_joins(:books).order(:id) }
+      let(:ordered_collection) { [user1, user2, user3, user4, user5] }
+
+      include_examples "works with first/last/before/after arguments"
+    end
+
+    context "when ordering based on an attribute of a joined table" do
+      let!(:user5) { User.create }
+      let!(:user2) { User.create }
+      let!(:user3) { User.create }
+      let!(:user1) { User.create }
+      let!(:user4) { User.create }
+
+      before do
+        Book.create(user: user1)
+        Book.create(user: user5)
+        Book.create(user: user2)
+        Book.create(user: user4)
+        Book.create(user: user3)
+      end
+
+      context "in ascending order" do
+        let(:relation) { User.joins(:books).order("books.created_at ASC") }
+        let(:ordered_collection) { [user1, user5, user2, user4, user3] }
+
+        include_examples "works with first/last/before/after arguments"
+      end
+
+      context "in descending order" do
+        let(:relation) { User.joins(:books).order("books.created_at DESC") }
+        let(:ordered_collection) { [user3, user4, user2, user5, user1] }
+
+        include_examples "works with first/last/before/after arguments"
+      end
+    end
+  end
+end

--- a/spec/cursor_pager/page_records_spec.rb
+++ b/spec/cursor_pager/page_records_spec.rb
@@ -72,18 +72,24 @@ RSpec.describe CursorPager::Page do
       end
 
       context "when no item could be found for the given `after`" do
-        let(:after_cursor) { encode_cursor(double(id: relation.maximum(:id) + 1)) }
+        let(:after_cursor) do
+          encode_cursor(double(id: relation.maximum(:id) + 1))
+        end
 
         it "returns the whole collection after the cursor" do
-          expect { subject.records }.to raise_error(CursorPager::CursorNotFoundError)
+          expect { subject.records }
+            .to raise_error(CursorPager::CursorNotFoundError)
         end
       end
 
       context "when no item could be found for the given `before`" do
-        let(:before_cursor) { encode_cursor(double(id: relation.maximum(:id) + 1)) }
+        let(:before_cursor) do
+          encode_cursor(double(id: relation.maximum(:id) + 1))
+        end
 
         it "returns the whole collection after the cursor" do
-          expect { subject.records }.to raise_error(CursorPager::CursorNotFoundError)
+          expect { subject.records }
+            .to raise_error(CursorPager::CursorNotFoundError)
         end
       end
     end
@@ -206,7 +212,8 @@ RSpec.describe CursorPager::Page do
       end
     end
 
-    context "it orders by ID secondarily when ordering by a non-datetime or primary key value" do
+    context "it orders by ID secondarily when ordering by a non-datetime or "\
+      "primary key value" do
       let!(:user1) { User.create(id: 1, name: "Bob") }
       let!(:user2) { User.create(id: 2, name: "Bob") }
       let!(:user3) { User.create(id: 3, name: "Alice") }

--- a/spec/cursor_pager/page_spec.rb
+++ b/spec/cursor_pager/page_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe CursorPager::Page do
+  describe "#previous_page?" do
+    it "returns false" do
+      page = described_class.new(User.all)
+
+      expect(page.previous_page?).to be(false)
+    end
+  end
+
+  describe "#next_page?" do
+    it "returns false" do
+      page = described_class.new(User.all)
+
+      expect(page.next_page?).to be(false)
+    end
+  end
+
+  describe "#cursor_for" do
+    it "returns the cursor for the item" do
+      item = User.new(id: 1)
+      page = described_class.new(User.all)
+
+      expect(page.cursor_for(item)).to eq("MQ==")
+    end
+  end
+
+  describe "#records" do
+    it "returns all the records of the relation" do
+      bob = User.create(name: "Bob")
+      alice = User.create(name: "Alice")
+      page = described_class.new(User.all)
+
+      expect(page.records).to contain_exactly(bob, alice)
+    end
+  end
+end

--- a/spec/cursor_pager/page_spec.rb
+++ b/spec/cursor_pager/page_spec.rb
@@ -3,16 +3,23 @@
 RSpec.describe CursorPager::Page do
   describe "#previous_page?" do
     context "when given `last`" do
-      let(:page) { described_class.new(User.all, last: 2) }
-
       it "returns true if it is smaller than the available edges" do
         3.times { User.create }
+        page = described_class.new(User.all, last: 2)
 
         expect(page.previous_page?).to be(true)
       end
 
       it "returns false if it equals or is bigger than the available edges" do
         2.times { User.create }
+        page = described_class.new(User.all, last: 2)
+
+        expect(page.previous_page?).to be(false)
+      end
+
+      it "does not break if the relation won't get an offset set" do
+        3.times { User.create }
+        page = described_class.new(User.limit(2), last: 3)
 
         expect(page.previous_page?).to be(false)
       end

--- a/spec/cursor_pager/page_spec.rb
+++ b/spec/cursor_pager/page_spec.rb
@@ -16,23 +16,4 @@ RSpec.describe CursorPager::Page do
       expect(page.next_page?).to be(false)
     end
   end
-
-  describe "#cursor_for" do
-    it "returns the cursor for the item" do
-      item = User.new(id: 1)
-      page = described_class.new(User.all)
-
-      expect(page.cursor_for(item)).to eq("MQ==")
-    end
-  end
-
-  describe "#records" do
-    it "returns all the records of the relation" do
-      bob = User.create(name: "Bob")
-      alice = User.create(name: "Alice")
-      page = described_class.new(User.all)
-
-      expect(page.records).to contain_exactly(bob, alice)
-    end
-  end
 end

--- a/spec/cursor_pager/page_spec.rb
+++ b/spec/cursor_pager/page_spec.rb
@@ -2,7 +2,30 @@
 
 RSpec.describe CursorPager::Page do
   describe "#previous_page?" do
-    it "returns false" do
+    context "when given `last`" do
+      let(:page) { described_class.new(User.all, last: 2) }
+
+      it "returns true if it is smaller than the available edges" do
+        3.times { User.create }
+
+        expect(page.previous_page?).to be(true)
+      end
+
+      it "returns false if it equals or is bigger than the available edges" do
+        2.times { User.create }
+
+        expect(page.previous_page?).to be(false)
+      end
+    end
+
+    it "returns true when given an `after` cursor" do
+      users = 2.times.map { User.create }
+      page = described_class.new(User.all, after: encode_cursor(users.first))
+
+      expect(page.previous_page?).to be(true)
+    end
+
+    it "returns false when given no arguments" do
       page = described_class.new(User.all)
 
       expect(page.previous_page?).to be(false)
@@ -10,10 +33,37 @@ RSpec.describe CursorPager::Page do
   end
 
   describe "#next_page?" do
-    it "returns false" do
+    context "when given `first" do
+      let(:page) { described_class.new(User.all, first: 2) }
+
+      it "returns true if it is smaller than the available edges" do
+        3.times { User.create }
+
+        expect(page.next_page?).to be(true)
+      end
+
+      it "returns false if it equals or is bigger than the available edges" do
+        2.times { User.create }
+
+        expect(page.next_page?).to be(false)
+      end
+    end
+
+    it "returns true when given a `before` cursor" do
+      users = 2.times.map { User.create }
+      page = described_class.new(User.all, before: encode_cursor(users.last))
+
+      expect(page.next_page?).to be(true)
+    end
+
+    it "returns false when given no arguments" do
       page = described_class.new(User.all)
 
       expect(page.next_page?).to be(false)
     end
+  end
+
+  def encode_cursor(item)
+    described_class.new(User.all).cursor_for(item)
   end
 end

--- a/spec/cursor_pager/slice_relation_spec.rb
+++ b/spec/cursor_pager/slice_relation_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe CursorPager::SliceRelation do
+  describe "#call" do
+    it "doesn't change the relation if before & after are nil" do
+      2.times { User.create }
+      relation = User.order(:id)
+      order_values = CursorPager::OrderValue.new(relation, "id")
+
+      sliced_relation = described_class
+        .new(relation, order_values, nil, nil).call
+
+      expect(sliced_relation).to eq(relation)
+    end
+
+    it "doesn't change the relation if before & after are empty" do
+      2.times { User.create }
+      relation = User.order(:id)
+      order_values = CursorPager::OrderValue.new(relation, "id")
+
+      sliced_relation = described_class.new(relation, order_values, [], []).call
+
+      expect(sliced_relation).to eq(relation)
+    end
+  end
+
+  # TODO: Move more tests over
+end

--- a/spec/cursor_pager/slice_relation_spec.rb
+++ b/spec/cursor_pager/slice_relation_spec.rb
@@ -2,27 +2,131 @@
 
 RSpec.describe CursorPager::SliceRelation do
   describe "#call" do
-    it "doesn't change the relation if before & after are nil" do
+    it "doesn't change the relation if before & after values are nil" do
       2.times { User.create }
       relation = User.order(:id)
-      order_values = CursorPager::OrderValue.new(relation, "id")
 
-      sliced_relation = described_class
-        .new(relation, order_values, nil, nil).call
+      sliced_relation = slice_relation(relation, nil, nil)
 
       expect(sliced_relation).to eq(relation)
     end
 
-    it "doesn't change the relation if before & after are empty" do
+    it "doesn't change the relation if before & after values are empty" do
       2.times { User.create }
       relation = User.order(:id)
-      order_values = CursorPager::OrderValue.new(relation, "id")
 
-      sliced_relation = described_class.new(relation, order_values, [], []).call
+      sliced_relation = slice_relation(relation, [], [])
 
       expect(sliced_relation).to eq(relation)
+    end
+
+    context "when the after values are not empty" do
+      context "when ordered by one attribute in ascending direction" do
+        it "correctly slices the relation" do
+          users = 5.times.map { User.create }
+          relation = User.order(:id)
+          cursor = [users[2].id]
+
+          sliced_relation = slice_relation(relation, cursor, [])
+
+          expect(sliced_relation).to eq(users[3..-1])
+        end
+      end
+
+      context "when ordered by one attribute in descending direction" do
+        it "correctly slices the relation" do
+          users = 5.times.map { User.create }.reverse
+          relation = User.order(id: :desc)
+          cursor = [users[2].id]
+
+          sliced_relation = slice_relation(relation, cursor, [])
+
+          expect(sliced_relation).to eq(users[3..-1])
+        end
+      end
+
+      context "when ordered by multiple attributes in ascending direction" do
+        it "correctly slices the relation" do
+          users = 5.times.map { User.create }
+          relation = User.order(id: :asc, created_at: :asc)
+          cursor = [users[2].id, users[2].created_at]
+
+          sliced_relation = slice_relation(relation, cursor, [])
+
+          expect(sliced_relation).to eq(users[3..-1])
+        end
+      end
+
+      context "when ordered by multiple attributes in descending direction" do
+        it "correctly slices the relation" do
+          users = 5.times.map { User.create }.reverse
+          relation = User.order(id: :desc, created_at: :desc)
+          cursor = [users[2].id, users[2].created_at]
+
+          sliced_relation = slice_relation(relation, cursor, [])
+
+          expect(sliced_relation).to eq(users[3..-1])
+        end
+      end
+    end
+
+    context "when the before values are not empty" do
+      context "when ordered by one attribute in ascending direction" do
+        it "correctly slices the relation" do
+          users = 5.times.map { User.create }
+          relation = User.order(:id)
+          cursor = [users[3].id]
+
+          sliced_relation = slice_relation(relation, [], cursor)
+
+          expect(sliced_relation).to eq(users[0..2])
+        end
+      end
+
+      context "when ordered by one attribute in descending direction" do
+        it "correctly slices the relation" do
+          users = 5.times.map { User.create }.reverse
+          relation = User.order(id: :desc)
+          cursor = [users[3].id]
+
+          sliced_relation = slice_relation(relation, [], cursor)
+
+          expect(sliced_relation).to eq(users[0..2])
+        end
+      end
+
+      context "when ordered by multiple attributes in ascending direction" do
+        it "correctly slices the relation" do
+          users = 5.times.map { User.create }
+          relation = User.order(id: :asc, created_at: :asc)
+          cursor = [users[3].id, users[3].created_at]
+
+          sliced_relation = slice_relation(relation, [], cursor)
+
+          expect(sliced_relation).to eq(users[0..2])
+        end
+      end
+
+      context "when ordered by multiple attributes in descending direction" do
+        it "correctly slices the relation" do
+          users = 5.times.map { User.create }.reverse
+          relation = User.order(id: :desc, created_at: :desc)
+          cursor = [users[3].id, users[3].created_at]
+
+          sliced_relation = slice_relation(relation, [], cursor)
+
+          expect(sliced_relation).to eq(users[0..2])
+        end
+      end
     end
   end
 
-  # TODO: Move more tests over
+  def slice_relation(relation, after_values, before_values)
+    described_class.new(
+      relation,
+      CursorPager::OrderValues.from_relation(relation),
+      after_values,
+      before_values
+    ).call
+  end
 end

--- a/spec/models.rb
+++ b/spec/models.rb
@@ -5,4 +5,9 @@ class ApplicationRecord < ActiveRecord::Base
 end
 
 class User < ApplicationRecord
+  has_many :books
+end
+
+class Book < ApplicationRecord
+  belongs_to :user
 end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -5,6 +5,7 @@ ActiveRecord::Schema.define do
 
   create_table :users, force: :cascade do |t|
     t.string :name
+    t.datetime :published_at
 
     t.timestamps
   end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -8,4 +8,11 @@ ActiveRecord::Schema.define do
 
     t.timestamps
   end
+
+  create_table :books, force: :cascade do |t|
+    t.string :name
+    t.integer :user_id
+
+    t.timestamps
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 require "bundler/setup"
 require "cursor_pager"
 require "active_record"
+require "database_cleaner/active_record"
 
 ActiveRecord::Base.establish_connection(
   ENV["DATABASE_URL"] ||
@@ -21,5 +22,16 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.around(:each) do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
   end
 end


### PR DESCRIPTION
This is a first go extracting all the stable pagination stuff we have in our application into this library. I had to add some more logic because we're not building on top of the GraphQL pagination anymore. Since this made the class pretty big I extracted a few classes.

The entry point is supposed to be the `Page` class. It works pretty similar to our GraphQL connection, just the naming is a bit more appropriate for Ruby.

```ruby
page = CursorPager::Page.new(User.all, first: 10, after: "aWQgNjI4OQ")
page.next_page?
page.previous_page?
page.cursor_for(user)
page.records
```

We can just wrap this into a connection to get it working in GraphQL. For REST APIs we could think about extending ActiveRecord like [kaminari](https://github.com/kaminari/kaminari#the-page-scope) is doing or add a helper method like [pagy](https://github.com/ddnexus/pagy#easy-to-use) is doing. But that's for another PR.

One thing to mention is that the cursor in here is currently not compatible to the cursor we have. We are prefixing the raw cursor value do that we can differentiate it from our old offset-based cursors. If you don't have to worry about backwards-compatibility  you don't really have to do this, which is why I haven't done it here. I plan to offer a way to override how the cursor is built in a separate PR. 