### PR TITLE
Configurable encoder

### DIFF
--- a/lib/cursor_pager.rb
+++ b/lib/cursor_pager.rb
@@ -9,8 +9,10 @@ end
 
 require "cursor_pager/conflicting_orders_error"
 require "cursor_pager/cursor_not_found_error"
+require "cursor_pager/invalid_cursor_error"
 require "cursor_pager/order_value_error"
 
+require "cursor_pager/base64_encoder"
 require "cursor_pager/order_value"
 require "cursor_pager/order_values"
 require "cursor_pager/limit_relation"

--- a/lib/cursor_pager.rb
+++ b/lib/cursor_pager.rb
@@ -12,6 +12,7 @@ require "cursor_pager/cursor_not_found_error"
 require "cursor_pager/invalid_cursor_error"
 require "cursor_pager/order_value_error"
 
+require "cursor_pager/configuration"
 require "cursor_pager/base64_encoder"
 require "cursor_pager/order_value"
 require "cursor_pager/order_values"

--- a/lib/cursor_pager/base64_encoder.rb
+++ b/lib/cursor_pager/base64_encoder.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module CursorPager
+  # Default encoder used to encode & decode cursors.
+  class Base64Encoder
+    class << self
+      def encode(data)
+        Base64.urlsafe_encode64(data)
+      end
+
+      def decode(data)
+        Base64.urlsafe_decode64(data)
+      rescue ArgumentError
+        raise InvalidCursorError, data
+      end
+    end
+  end
+end

--- a/lib/cursor_pager/configuration.rb
+++ b/lib/cursor_pager/configuration.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Top level module on which the configuration will be applied.
+module CursorPager
+  # Encapulates all the configuration for the library.
+  class Configuration
+    # The encoder that will be used to encode & decode cursors.
+    attr_accessor :encoder
+
+    def initialize
+      @encoder = Base64Encoder
+    end
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configuration=(config)
+    @configuration = config
+  end
+
+  def self.reset
+    @configuration = Configuration.new
+  end
+
+  def self.configure
+    yield(configuration)
+  end
+end

--- a/lib/cursor_pager/cursor_not_found_error.rb
+++ b/lib/cursor_pager/cursor_not_found_error.rb
@@ -4,7 +4,7 @@ module CursorPager
   # Will be raised when the cursor's record couldn't be found in the relation.
   class CursorNotFoundError < Error
     def initialize(cursor)
-      message = "Couldn't find item for cursor #{cursor}."
+      message = "Couldn't find item for cursor: #{cursor}."
 
       super(message)
     end

--- a/lib/cursor_pager/invalid_cursor_error.rb
+++ b/lib/cursor_pager/invalid_cursor_error.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module CursorPager
+  # Will be raise when the cursor couldn't be parsed.
+  class InvalidCursorError < Error
+    def initialize(cursor)
+      message = "Couldn't parse cursor: #{cursor}."
+
+      super(message)
+    end
+  end
+end

--- a/lib/cursor_pager/page.rb
+++ b/lib/cursor_pager/page.rb
@@ -38,7 +38,7 @@ module CursorPager
     end
 
     def cursor_for(item)
-      Base64Encoder.encode(item.id.to_s)
+      encoder.encode(item.id.to_s)
     end
 
     def records
@@ -85,17 +85,15 @@ module CursorPager
     end
 
     def before_limit_value
-      @before_limit_value ||= before && limit_value_for(before)
+      @before_limit_value ||= before.present? && limit_value_for(before)
     end
 
     def after_limit_value
-      @after_limit_value ||= after && limit_value_for(after)
+      @after_limit_value ||= after.present? && limit_value_for(after)
     end
 
     def limit_value_for(cursor)
-      id = Base64Encoder.decode(cursor)
-
-      return if id.blank?
+      id = encoder.decode(cursor)
 
       selects = order_values.map(&:select_string)
       item = relation.where(id: id).select(selects).first
@@ -103,6 +101,10 @@ module CursorPager
       raise CursorNotFoundError, cursor if item.blank?
 
       order_values.map { |value| item[value.select_alias] }
+    end
+
+    def encoder
+      CursorPager.configuration.encoder
     end
   end
 end

--- a/lib/cursor_pager/page.rb
+++ b/lib/cursor_pager/page.rb
@@ -38,7 +38,7 @@ module CursorPager
     end
 
     def cursor_for(item)
-      Base64.urlsafe_encode64(item.id.to_s)
+      Base64Encoder.encode(item.id.to_s)
     end
 
     def records
@@ -93,7 +93,7 @@ module CursorPager
     end
 
     def limit_value_for(cursor)
-      id = Base64.urlsafe_decode64(cursor)
+      id = Base64Encoder.decode(cursor)
 
       return if id.blank?
 

--- a/spec/cursor_pager/base64_encoder_spec.rb
+++ b/spec/cursor_pager/base64_encoder_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe CursorPager::Base64Encoder do
+  describe ".encode" do
+    it "base64 encodes the data" do
+      expect(described_class.encode("1")).to eq("MQ==")
+    end
+  end
+
+  describe ".decode" do
+    it "decodes base64 encoded data" do
+      expect(described_class.decode("MQ==")).to eq("1")
+    end
+
+    it "raises an InvalidCursorError for not-base64-encoded data" do
+      expect { described_class.decode("123123") }
+        .to raise_error(CursorPager::InvalidCursorError)
+    end
+  end
+end

--- a/spec/cursor_pager/configuration_spec.rb
+++ b/spec/cursor_pager/configuration_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe CursorPager::Configuration do
+  after { CursorPager.reset }
+
+  context "when no encoder is specified" do
+    it "defaults to Base64Encoder" do
+      expect(CursorPager.configuration.encoder)
+        .to eq(CursorPager::Base64Encoder)
+    end
+  end
+
+  context "when a custom encoder is specified" do
+    it "uses the custom encoder" do
+      encoder = Class.new
+
+      CursorPager.configure { |config| config.encoder = encoder }
+
+      expect(CursorPager.configuration.encoder).to eq(encoder)
+    end
+  end
+end

--- a/spec/cursor_pager/page_records_spec.rb
+++ b/spec/cursor_pager/page_records_spec.rb
@@ -26,6 +26,14 @@ RSpec.describe CursorPager::Page do
         end
       end
 
+      context "when given an empty `after`" do
+        let(:after_cursor) { "" }
+
+        it "returns the whole collection" do
+          expect(subject.records).to eq(ordered_collection)
+        end
+      end
+
       context "when given `first` and `after`" do
         let(:offset) { 1 }
         let(:first) { 2 }
@@ -56,6 +64,14 @@ RSpec.describe CursorPager::Page do
           expected = ordered_collection.first(offset)
 
           expect(subject.records).to eq(expected)
+        end
+      end
+
+      context "when given an empty `before`" do
+        let(:before_cursor) { "" }
+
+        it "returns the whole collection" do
+          expect(subject.records).to eq(ordered_collection)
         end
       end
 


### PR DESCRIPTION
We're encoding the cursors by default with Base64 but since the cursor equals the record's ID some might want further obfuscate the cursor value. Making the encoder configurable allows users to do this.