### PR TITLE
default_page_size & maximum_page_size configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,5 +18,8 @@ Metrics/BlockLength:
   Exclude:
     - /**/spec/**/*
 
+Metrics/ClassLength:
+  Max: 200
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ page.records
 
 ## Configuration
 
+### Encoder
+
 By default cursors are base64 encoded primary keys of the records. If you wish
 to change that because you want to add encryption or something similiar, you
 can provide your own encoder class.
@@ -84,6 +86,18 @@ end
 
 CursorPager.configure do |config|
   config.encoder = CustomEncoder
+end
+```
+
+### Default & Maximum Page Size
+
+The default & maximum page sizes are configured as `nil` (unlimited) by default.
+You can however set your own values.
+
+```ruby
+CursorPager.configure do |config|
+  config.default_page_size = 25
+  config.maximum_page_size = 100
 end
 ```
 

--- a/lib/cursor_pager/configuration.rb
+++ b/lib/cursor_pager/configuration.rb
@@ -5,10 +5,24 @@ module CursorPager
   # Encapulates all the configuration for the library.
   class Configuration
     # The encoder that will be used to encode & decode cursors.
+    # Defaults to `Base64Encoder`.
     attr_accessor :encoder
+
+    # The default page size that will be used if no `first` or `last` were
+    # specified. Every record fitting the cursor constraints will be returned
+    # if it's set to `nil`.
+    # Defaults to `nil`.
+    attr_accessor :default_page_size
+
+    # The maximum allowed page size. Clients will never receive more records per
+    # page than is sepcified here. There is no maximum if this is set to `nil`.
+    # Defaults to `nil`.
+    attr_accessor :maximum_page_size
 
     def initialize
       @encoder = Base64Encoder
+      @default_page_size = nil
+      @maximum_page_size = nil
     end
   end
 

--- a/lib/cursor_pager/page.rb
+++ b/lib/cursor_pager/page.rb
@@ -31,7 +31,11 @@ module CursorPager
     def first
       @first ||= begin
                    capped = limit_pagination_argument(first_value)
-                   capped = default_page_size if capped.nil? && last.nil?
+
+                   if capped.nil? && last.nil?
+                     capped = default_page_size || maximum_page_size
+                   end
+
                    capped
                  end
     end

--- a/lib/cursor_pager/page.rb
+++ b/lib/cursor_pager/page.rb
@@ -3,18 +3,43 @@
 module CursorPager
   # The main class that coordinates the whole pagination.
   class Page
-    attr_reader :relation, :first, :last, :after, :before, :order_values
+    extend Forwardable
+
+    attr_reader :relation, :first_value, :last_value, :after, :before,
+      :order_values
+
+    def_delegators :@configuration, :encoder, :default_page_size,
+      :maximum_page_size
 
     def initialize(relation, first: nil, last: nil, after: nil, before: nil)
+      @configuration = CursorPager.configuration
       @relation = relation
-      @first = first
-      @last = last
+      @first_value = first
+      @last_value = last
       @after = after
       @before = before
       @order_values = OrderValues.from_relation(relation)
 
       add_default_order
       verify_order_directions!
+    end
+
+    # A capped `first` value.
+    # The underlying instance variable `first_value` doesn't have limits on it.
+    # If neither `first` nor `last` is given, but `default_page_size` is
+    # configured, `default_page_size` is used for first.
+    def first
+      @first ||= begin
+                   capped = limit_pagination_argument(first_value)
+                   capped = default_page_size if capped.nil? && last.nil?
+                   capped
+                 end
+    end
+
+    # A capped `last` value.
+    # The underlying instance variable `last_value` doesn't have limits on it.
+    def last
+      @last ||= limit_pagination_argument(last_value)
     end
 
     def previous_page?
@@ -38,19 +63,17 @@ module CursorPager
     end
 
     def cursor_for(item)
+      return if item.nil?
+
       encoder.encode(item.id.to_s)
     end
 
     def first_cursor
-      first_record = records.first
-
-      first_record && cursor_for(first_record)
+      cursor_for(records.first)
     end
 
     def last_cursor
-      last_record = records.last
-
-      last_record && cursor_for(last_record)
+      cursor_for(records.last)
     end
 
     def records
@@ -77,6 +100,21 @@ module CursorPager
       return if order_values.map(&:direction).uniq.size == 1
 
       raise ConflictingOrdersError
+    end
+
+    # Used to cap `first` and `last` arguments.
+    # Returns `nil` if the argument is `nil`, otherwise a value between `0` and
+    # `maximum_page_size`.
+    def limit_pagination_argument(argument)
+      return if argument.nil?
+
+      if argument.negative?
+        argument = 0
+      elsif maximum_page_size && argument > maximum_page_size
+        argument = maximum_page_size
+      end
+
+      argument
     end
 
     def limited_relation
@@ -113,10 +151,6 @@ module CursorPager
       raise CursorNotFoundError, cursor if item.blank?
 
       order_values.map { |value| item[value.select_alias] }
-    end
-
-    def encoder
-      CursorPager.configuration.encoder
     end
   end
 end

--- a/lib/cursor_pager/page.rb
+++ b/lib/cursor_pager/page.rb
@@ -26,8 +26,8 @@ module CursorPager
 
     # A capped `first` value.
     # The underlying instance variable `first_value` doesn't have limits on it.
-    # If neither `first` nor `last` is given, but `default_page_size` is
-    # configured, `default_page_size` is used for first.
+    # If neither `first` nor `last` is given, but `default_page_size` or
+    # `maximum_page_size` are configured, they will be used for first.
     def first
       @first ||= begin
                    capped = limit_pagination_argument(first_value)

--- a/spec/cursor_pager/configuration_spec.rb
+++ b/spec/cursor_pager/configuration_spec.rb
@@ -19,4 +19,32 @@ RSpec.describe CursorPager::Configuration do
       expect(CursorPager.configuration.encoder).to eq(encoder)
     end
   end
+
+  context "when no default_page_size is specified" do
+    it "defaults to nil" do
+      expect(CursorPager.configuration.default_page_size).to be_nil
+    end
+  end
+
+  context "when a default_page_size is specified" do
+    it "uses the custom default_page_size" do
+      CursorPager.configuration.default_page_size = 25
+
+      expect(CursorPager.configuration.default_page_size).to eq(25)
+    end
+  end
+
+  context "when no maximum_page_size is specified" do
+    it "defaults to nil" do
+      expect(CursorPager.configuration.maximum_page_size).to be_nil
+    end
+  end
+
+  context "when a maximum_page_size is specified" do
+    it "uses the custom maximum_page_size" do
+      CursorPager.configuration.maximum_page_size = 25
+
+      expect(CursorPager.configuration.maximum_page_size).to eq(25)
+    end
+  end
 end

--- a/spec/cursor_pager/page_spec.rb
+++ b/spec/cursor_pager/page_spec.rb
@@ -1,6 +1,73 @@
 # frozen_string_literal: true
 
 RSpec.describe CursorPager::Page do
+  describe "#first" do
+    it "returns the specified value if it doesn't need to be modified" do
+      page = described_class.new(User.none, first: 25)
+
+      expect(page.first).to eq(25)
+    end
+
+    it "returns `0` if a negative value was used" do
+      page = described_class.new(User.none, first: -25)
+
+      expect(page.first).to eq(0)
+    end
+
+    it "returns the `maximum_page_size` if it's smaller then the given value" do
+      CursorPager.configuration.maximum_page_size = 10
+      page = described_class.new(User.none, first: 25)
+
+      expect(page.first).to eq(10)
+
+      CursorPager.reset
+    end
+
+    it "returns nil if no `first` and `last` and no default was configurated" do
+      page = described_class.new(User.none, first: nil, last: nil)
+
+      expect(page.first).to eq(nil)
+    end
+
+    it "returns the configured default when `first` and `last` were provided" do
+      CursorPager.configuration.default_page_size = 10
+      page = described_class.new(User.none, first: nil, last: nil)
+
+      expect(page.first).to eq(10)
+
+      CursorPager.reset
+    end
+  end
+
+  describe "#last" do
+    it "returns the specified value if it doesn't need to be modified" do
+      page = described_class.new(User.none, last: 25)
+
+      expect(page.last).to eq(25)
+    end
+
+    it "returns nil if `nil` was used" do
+      page = described_class.new(User.none, last: nil)
+
+      expect(page.first).to eq(nil)
+    end
+
+    it "returns `0` if a negative value was used" do
+      page = described_class.new(User.none, last: -25)
+
+      expect(page.last).to eq(0)
+    end
+
+    it "returns the `maximum_page_size` if it's smaller then the given value" do
+      CursorPager.configuration.maximum_page_size = 10
+      page = described_class.new(User.none, last: 25)
+
+      expect(page.last).to eq(10)
+
+      CursorPager.reset
+    end
+  end
+
   describe "#previous_page?" do
     context "when given `last`" do
       it "returns true if it is smaller than the available edges" do

--- a/spec/cursor_pager/page_spec.rb
+++ b/spec/cursor_pager/page_spec.rb
@@ -23,19 +23,30 @@ RSpec.describe CursorPager::Page do
       CursorPager.reset
     end
 
-    it "returns nil if no `first` and `last` and no default was configurated" do
-      page = described_class.new(User.none, first: nil, last: nil)
+    context "when `first` and `last` were not provided" do
+      it "returns nil if no default or maximum were configured" do
+        page = described_class.new(User.none, first: nil, last: nil)
 
-      expect(page.first).to eq(nil)
-    end
+        expect(page.first).to eq(nil)
+      end
 
-    it "returns the configured default when `first` and `last` were provided" do
-      CursorPager.configuration.default_page_size = 10
-      page = described_class.new(User.none, first: nil, last: nil)
+      it "returns the configured default" do
+        CursorPager.configuration.default_page_size = 10
+        page = described_class.new(User.none, first: nil, last: nil)
 
-      expect(page.first).to eq(10)
+        expect(page.first).to eq(10)
 
-      CursorPager.reset
+        CursorPager.reset
+      end
+
+      it "returs the configured maximum when no default was configured" do
+        CursorPager.configuration.maximum_page_size = 100
+        page = described_class.new(User.none, first: nil, last: nil)
+
+        expect(page.first).to eq(100)
+
+        CursorPager.reset
+      end
     end
   end
 


### PR DESCRIPTION
Users can now define `default_page_size` and `maximum_page_size`. They still default to `nil`. 

The `default_page_size` will be used as `first` value, when no `first` or `last` are specified by the user.

The `maximum_page_size` caps provided `first` and `last` values, but will also be used as `first`, when no `first` or `last` are specified and `default_page_size` isn't configured.

Closes #5.