### PR TITLE
Use reordered relation to fetch cursor record

### DIFF
--- a/lib/cursor_pager/page.rb
+++ b/lib/cursor_pager/page.rb
@@ -150,7 +150,7 @@ module CursorPager
       id = encoder.decode(cursor)
 
       selects = order_values.map(&:select_string)
-      item = relation.where(id: id).select(selects).first
+      item = ordered_relation.where(id: id).select(selects).first
 
       raise CursorNotFoundError, cursor if item.blank?
 

--- a/spec/cursor_pager/page_records_spec.rb
+++ b/spec/cursor_pager/page_records_spec.rb
@@ -295,18 +295,27 @@ RSpec.describe CursorPager::Page do
       let!(:user3) { User.create(id: 3) }
       let!(:user4) { User.create(id: 4) }
       let!(:user5) { User.create(id: 5) }
-      let(:relation) { User.left_outer_joins(:books).order(:id) }
       let(:ordered_collection) { [user1, user2, user3, user4, user5] }
 
-      include_examples "works with first/last/before/after arguments"
+      context "and the order values are keywords" do
+        let(:relation) { User.left_outer_joins(:books).order(:id) }
+
+        include_examples "works with first/last/before/after arguments"
+      end
+
+      context "and the order values are strings" do
+        let(:relation) { User.left_outer_joins(:books).order("id") }
+
+        include_examples "works with first/last/before/after arguments"
+      end
     end
 
     context "when ordering based on an attribute of a joined table" do
-      let!(:user5) { User.create }
-      let!(:user2) { User.create }
-      let!(:user3) { User.create }
-      let!(:user1) { User.create }
-      let!(:user4) { User.create }
+      let(:user5) { User.create }
+      let(:user2) { User.create }
+      let(:user3) { User.create }
+      let(:user1) { User.create }
+      let(:user4) { User.create }
 
       before do
         Book.create(user: user1)


### PR DESCRIPTION
To fetch the cursor values we’re only selecting the needed values with an alias, so order values without the table prefix become ambiguous if there is a join.